### PR TITLE
feat: add Nix flake for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ TODO.md
 .claude/doc/
 temp/
 templates/
+# Nix build output
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ kilm status
 
 > **[Complete Installation Guide](https://kilm.aristovnik.me/guides/installation/)** - Multiple installation methods, verification steps, and troubleshooting.
 
+## Nix
+
+Run without installing:
+
+```bash
+nix run github:barisgit/KiLM -- --version
+```
+
+Build, or drop into a dev shell:
+
+```bash
+nix build github:barisgit/KiLM   # ./result/bin/kilm
+nix develop                      # dev shell with pytest + ruff
+```
+
+Add to a NixOS / home-manager config via the overlay:
+
+```nix
+{
+  inputs.kilm.url = "github:barisgit/KiLM";
+
+  # in your config:
+  nixpkgs.overlays = [ inputs.kilm.overlays.default ];
+  environment.systemPackages = [ pkgs.kilm ];  # or home.packages
+}
+```
+
 ## Documentation
 
 **[Complete Documentation](https://kilm.aristovnik.me)**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/567a49d1913ce81ac6e9582e3553dd90a955875f.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/567a49d1913ce81ac6e9582e3553dd90a955875f.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  # Pin nixpkgs, select dep versions, wire overlay, expose outputs.
+  # NO build logic here — that lives in pkgs/kilm.nix.
+  description = "Flake for kilm (KiCad Library Manager)";
+
+  inputs = {
+    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/567a49d1913ce81ac6e9582e3553dd90a955875f.tar.gz";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      out = system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          applied = self.overlays.default pkgs pkgs;
+        in {
+          packages.kilm = applied.kilm;
+          packages.default = applied.kilm;
+
+          # `nix run github:barisgit/KiLM` and `nix run .#kilm`.
+          apps.kilm = flake-utils.lib.mkApp { drv = applied.kilm; };
+          apps.default = flake-utils.lib.mkApp { drv = applied.kilm; };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ applied.kilm ];
+            packages = with pkgs.python3Packages; [ pytest ruff ];
+          };
+        };
+    in
+      flake-utils.lib.eachDefaultSystem out // {
+        overlays.default = final: prev:
+          let
+            python3Packages = prev.python3Packages;
+          in {
+            kilm =
+              (prev.callPackage ./pkgs/kilm.nix {
+                inherit python3Packages;
+                inherit (prev) git;
+              }).overrideAttrs (old: {
+                # Local in-tree source.
+                src = self;
+              });
+          };
+      };
+}

--- a/pkgs/kilm.nix
+++ b/pkgs/kilm.nix
@@ -1,0 +1,46 @@
+{
+  # Build logic for kilm (KiCad Library Manager). buildPythonPackage, hatchling backend.
+  # Invoked via callPackage; `src` is overridden by the flake overlay.
+  python3Packages,
+  git,
+}:
+
+python3Packages.buildPythonPackage {
+  pname = "kilm";
+  version = "0.5.5";
+  pyproject = true;
+
+  src = null; # flake overrides via overrideAttrs
+
+  build-system = with python3Packages; [ hatchling ];
+
+  # `pathlib` is declared in pyproject but is stdlib; the PyPI backport is a
+  # no-op and absent from nixpkgs, so drop the requirement.
+  pythonRemoveDeps = [ "pathlib" ];
+
+  # Runtime deps from pyproject. `pathlib` dep dropped: stdlib since py3, the PyPI
+  # backport is a no-op on a modern interpreter.
+  dependencies = with python3Packages; [
+    click
+    typer
+    rich
+    packaging
+    pyyaml
+    pathspec
+    jinja2
+    questionary
+    requests
+  ];
+
+  nativeCheckInputs = [ git ] ++ (with python3Packages; [ pytest-cov pytestCheckHook ]);
+
+  # Tests shell out to `git` and write into HOME; give them a writable one.
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = {
+    description = "Command-line tool for managing KiCad libraries across projects and workstations";
+    mainProgram = "kilm";
+  };
+}


### PR DESCRIPTION
  ## What Changed
  
  Packages KiLM as a Nix flake so it can be built, run, and installed reproducibly via Nix.

  ## Outputs
  
  | Output | Command |
  |--------|---------|
  | `packages.default` / `.kilm` | `nix build github:barisgit/KiLM` |
  | `apps.default` / `.kilm` | `nix run github:barisgit/KiLM` |
  | `devShells.default` | `nix develop` (pytest + ruff) |
  | `overlays.default` | `pkgs.kilm` in a NixOS / home-manager config |

  ## Structure
  
  Follows the two-file split (build logic kept out of the flake):

  - `flake.nix` — pins nixpkgs, wires the overlay, exposes outputs. No build logic.
  - `pkgs/kilm.nix` — `buildPythonPackage` (hatchling), deps, tests, via `callPackage`.

  ## Notes
  
  - `pythonRemoveDeps = ["pathlib"]` — pyproject declares the dead PyPI `pathlib` backport; it's stdlib on py3 and absent from nixpkgs.
  - Tests need `git` and a writable `$HOME`, both wired in `nativeCheckInputs` / `preCheck`.
  - Multi-platform via `flake-utils.lib.eachDefaultSystem`.

  ## Verification
```bash
  nix flake check       # all checks pass
  nix build .#kilm      # 112 tests pass
  nix run .#kilm -- --version
```
  ## Changes

  - `flake.nix`, `flake.lock`, `pkgs/kilm.nix` — the flake
  - `README.md` — Nix usage section
  - `.gitignore` — ignore `result` symlinks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix support for running, building, and developing the project with `nix run`, `nix build`, and `nix develop`.
  * Added a Nix flake so the app can be used as a package, runnable app, or dev shell.
  * Documented how to integrate the project into NixOS and home-manager setups.

* **Chores**
  * Updated ignore rules for generated Nix build outputs and templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->